### PR TITLE
Base explicite des URLs de ressources

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,13 @@ Deux variables d'environnement doivent être configurées dans l'[onglet Setting
 
 Il existe 2 environnements :
 
-* **démo autonome** : `npm run build-demo:public` (dans le cadre du déploiement continu)
+* **démo autonome** : `npm run build-demo` (construite par l'intégration continue)
 * **développement** : `npm run watch`
+
+| Variable d'environnement  | Valeur par défaut | Utilité
+| ---                       | ---               | ---
+| `BASE_URL`   | `https://dtc-innovation.github.io/dataviz-finances-montreuil`  | Explicite où sont hébergées les données et _assets_ de l'application.
+| `NODE_ENV`   | `undefined`  | Optimise les artéfacts lorsque la valeur est `production`.
 
 ## Mise à jour des données financières
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "http-server --cors -p 3000 -a 127.0.0.1 .",
     "start": "run-p serve watch:*",
     "test": "jest",
-    "build-demo": "cross-env NODE_ENV=demo npm-run-all --serial build-demo:public build:m52overview",
+    "build-demo": "cross-env NODE_ENV=demo BASE_URL=${BASE_URL:=https://dtc-innovation.github.io/dataviz-finances-montreuil} npm-run-all --serial build-demo:public build:m52overview",
     "build:m52overview": "npm-run-all build:m52overview:script",
     "build:m52overview:script": "browserify src/m52-overview/js/main.js -o build/m52-overview-bundle.js -d",
     "build-demo:public": "npm-run-all --serial build:public:data:* --parallel build:public:style build:public:script",
@@ -18,9 +18,9 @@
     "build:public:data:finance-data": "node -r esm tools/make-public-data.js",
     "build:public:data:m52-strings": "node -r esm tools/make-doc-budg-strings.js",
     "dl:plans-de-compte": "npx github:dtc-innovation/plans-de-compte --in data/finances/CA --out data/finances/plansDeCompte",
-    "watch:m52overview": "cross-env NODE_ENV=development watchify src/m52-overview/js/main.js -o build/m52-overview-bundle.js -d -v",
+    "watch:m52overview": "cross-env NODE_ENV=development BASE_URL=http://localhost:3000 watchify src/m52-overview/js/main.js -o build/m52-overview-bundle.js -d -v",
     "prewatch:public": "run-s build:public:data:*",
-    "watch:public": "cross-env NODE_ENV=development npm-run-all --parallel watch:public:*",
+    "watch:public": "cross-env NODE_ENV=development BASE_URL=http://localhost:3000 npm-run-all --parallel watch:public:*",
     "prewatch:public:style": "npm run build:public:style",
     "watch:public:style": "node-sass --importer src/public/style/env-importer.js --watch src/public/style/main.scss build/public.css",
     "watch:public:script": "watchify src/public/js/main.js -o build/dataviz-finance-bundle.js -d -v",
@@ -59,6 +59,7 @@
               "transform-inline-environment-variables",
               {
                 "include": [
+                  "BASE_URL",
                   "NODE_ENV"
                 ]
               }

--- a/src/public/js/constants/resources.js
+++ b/src/public/js/constants/resources.js
@@ -7,30 +7,18 @@ export const M52_FONCTION_TEMPORAL = "M52_FONCTION_TEMPORAL";
 
 export const CORRECTIONS_AGGREGATED = "CORRECTIONS_AGGREGATED";
 
-const env = process.env.NODE_ENV;
+const {BASE_URL} = process.env;
+
+if (!BASE_URL) {
+    throw new TypeError('Please define a BASE_URL env variable. The README will tell you more.');
+}
 
 export const assets = {
     // finance data
-    [COMPTES_ADMINISTRATIFS]: {
-        "production": undefined,
-        "demo": `../build/finances/doc-budgs.json`,
-        "development": `../build/finances/doc-budgs.json`,
-    }[env],
-    [CORRECTIONS_AGGREGATED]: {
-        "production": undefined,
-        "demo": `../data/finances/corrections-agregation.csv`,
-        "development": `/data/finances/corrections-agregation.csv`
-    }[env],
+    [COMPTES_ADMINISTRATIFS]: `${BASE_URL}/build/finances/doc-budgs.json`,
+    [CORRECTIONS_AGGREGATED]: `${BASE_URL}/data/finances/corrections-agregation.csv`,
 
     // texts
-    [AGGREGATED_ATEMPORAL]: {
-        "production": undefined,
-        "demo": `../data/texts/aggregated-atemporal.csv`,
-        "development": `../data/texts/aggregated-atemporal.csv`
-    }[env],
-    [AGGREGATED_TEMPORAL]: {
-        "production": undefined,
-        "demo":  `/../data/texts/aggregated-temporal.csv`,
-        "development": `../data/texts/aggregated-temporal.csv`
-    }[env]
+    [AGGREGATED_ATEMPORAL]: `${BASE_URL}/data/texts/aggregated-atemporal.csv`,
+    [AGGREGATED_TEMPORAL]: `${BASE_URL}/data/texts/aggregated-temporal.csv`,
 }


### PR DESCRIPTION
Comme ça le build JS peut être chargé sur une page du site de Montreuil et télécharger les bons fichiers JSON.

fix #41 