### PR TITLE
La proportionnalité des montants est par ensemble et pas globale

### DIFF
--- a/src/shared/js/components/BubbleChartCluster.js
+++ b/src/shared/js/components/BubbleChartCluster.js
@@ -42,32 +42,25 @@ export default function BubbleChartCluster({tree}){
 
     // PROBLEM This is super-hardcoded
     const families = tree
-        .children.toJS()
-        .map(node => {
+        .children
+        .map(node1 => {
             return {
-                id: node.id,
-                label: node.label,
-                total: aggregatedDocumentBudgetaireNodeTotal(node),
+                id: node1.id,
+                label: node1.label,
+                total: aggregatedDocumentBudgetaireNodeTotal(node1),
                 rdfi: 'DF',
-                children: node.children.map(c => {
+                children: node1.children.map(node2 => {
                     return {
-                        id: c.id,
-                        label: c.label,
-                        total: aggregatedDocumentBudgetaireNodeTotal(c),
-                        rdfi: 'DF',
-                        children: node.children.map(c => {
-                            return {
-                                id: c.id,
-                                label: c.label,
-                                total: aggregatedDocumentBudgetaireNodeTotal(c),
-                                rdfi: 'DF'
-                            }
-                        })
+                        id: node2.id,
+                        label: node2.label,
+                        total: aggregatedDocumentBudgetaireNodeTotal(node2),
+                        rdfi: 'DF'
                     }
                 })
             }
         })
         .sort((a, b) => b.total - a.total)
+        .toJS()
 
     console.log('families', families)
     const maxNodeValue = max([].concat(...families.map(f => f.children)), f => f.total);

--- a/src/shared/js/components/BubbleChartCluster.js
+++ b/src/shared/js/components/BubbleChartCluster.js
@@ -3,6 +3,8 @@ import React from 'react';
 import { hierarchicalByFunction } from "../finance/memoized.js";
 import {aggregatedDocumentBudgetaireNodeTotal} from "../finance/AggregationDataStructures.js"
 
+import {max} from "d3-array";
+
 import MoneyAmount from "./MoneyAmount.js";
 import BubbleChartNode from "./BubbleChartNode.js";
 
@@ -13,6 +15,7 @@ const mergeHierarchies = (...hierarchies) => {
     hierarchies.forEach(children => {
         children.forEach(node => {
             const {id, label, children} = node
+            // We get the '122' part of `M52-DF-122`
             const levelId = id.split('-').pop();
 
             if (!levels.has(levelId)) {

--- a/src/shared/js/components/BubbleChartCluster.js
+++ b/src/shared/js/components/BubbleChartCluster.js
@@ -67,8 +67,12 @@ export default function BubbleChartCluster({tree}){
                 })
             }
         })
+        .sort((a, b) => b.total - a.total)
+
+    console.log('families', families)
+    const maxNodeValue = max([].concat(...families.map(f => f.children)), f => f.total);
 
     return (<div className="bubble-chart-cluster">
-        {families.map((node) => (<BubbleChartNode key={`rd-CH${node.id}`} node={node} />))}
+        {families.map((node) => (<BubbleChartNode key={`rd-CH${node.id}`} node={node} maxNodeValue={maxNodeValue} />))}
     </div>)
 }

--- a/src/shared/js/components/BubbleChartNode.js
+++ b/src/shared/js/components/BubbleChartNode.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import page from 'page'
 import {pack, hierarchy} from 'd3-hierarchy';
+import {scaleLinear} from 'd3-scale';
+
 import ReactTooltip from 'react-tooltip'
 
 import MoneyAmount from "./MoneyAmount.js";
@@ -12,14 +14,16 @@ export default class BubbleChartNode extends React.Component {
     }
 
     render() {
-        const {node} = this.props;
+        const {node, maxNodeValue} = this.props;
         const {total, label, children} = node;
         const WIDTH = 400;
         const HEIGHT = 400;
+        const r = scaleLinear().domain([0, maxNodeValue]).range([0, WIDTH / 2]);
 
         const bubbles = pack({children})
             .size([WIDTH, HEIGHT])
-            .padding(30);
+            .radius(d => Math.max(r(d.value), 3))
+            .padding(20);
         const nodes = hierarchy({children}).sum(d => d.total);
         const listMapNodes = new Map(bubbles(nodes)
             .descendants()

--- a/src/shared/js/components/BubbleChartNode.js
+++ b/src/shared/js/components/BubbleChartNode.js
@@ -16,20 +16,21 @@ export default class BubbleChartNode extends React.Component {
     render() {
         const {node, maxNodeValue} = this.props;
         const {total, label, children} = node;
+        const RorD = node.rdfi[0];
         const WIDTH = 400;
         const HEIGHT = 400;
-        const r = scaleLinear().domain([0, maxNodeValue]).range([0, WIDTH / 2]);
+        const radius = scaleLinear().domain([0, maxNodeValue]).range([0, WIDTH / 2]);
 
-        const bubbles = pack({children})
+        const nodes = hierarchy({name: label, children})
+            .sort((a, b) => b.total - a.total);
+
+        const bubbles = pack()
             .size([WIDTH, HEIGHT])
-            .radius(d => Math.max(r(d.value), 3))
-            .padding(20);
-        const nodes = hierarchy({children}).sum(d => d.total);
-        const listMapNodes = new Map(bubbles(nodes)
-            .descendants()
-            .filter(d => !d.children)
-            .map((obj) => [obj.data.id, obj]))
-        const RorD = listMapNodes.values().next().value.data.rdfi[0]
+            .padding(10)
+            .radius(d => radius(d.data.total))
+
+        const listMapNodes = bubbles(nodes).children;
+        console.log(label, listMapNodes)
 
         return (<figure className={`bubble-chart rdfi-${RorD}`}>
             <figurelegend>
@@ -41,8 +42,7 @@ export default class BubbleChartNode extends React.Component {
                 {[...listMapNodes.values()].map(({r, x, y, data}) => (
                     <g key={data.id} transform={`translate(${x}, ${y})`}>
                         <a
-                            // href={}
-                            onClick={e => page(`/finance-details/${data.id}`)}
+                            href={`#!/finance-details/${data.id}`}
                             className="clickable"
                             onFocus={e => ReactTooltip.show(e.target)}
                             onBlur={e => ReactTooltip.hide(e.target)}
@@ -67,7 +67,7 @@ export default class BubbleChartNode extends React.Component {
                 effect='solid'
                 getContent={(nodeId) => {
                     if (!nodeId) return null;
-                    const data = listMapNodes.get(nodeId).data;
+                    const {data} = listMapNodes.find(d => d.id === nodeId).pop();
                     return (<div className={`rdfi-${data.rdfi[0]} rdfi-${data.rdfi[1]}`}>
                         <p className='react-tooltip-type-aggregation'>
                             {data.rdfi[0] === 'R'? 'Recette': 'Dépense'}

--- a/src/shared/js/components/BubbleChartNode.js
+++ b/src/shared/js/components/BubbleChartNode.js
@@ -43,6 +43,7 @@ export default class BubbleChartNode extends React.Component {
                         <a
                             // href={`#!/finance-details/${data.id}`}
                             onClick={e => e.preventDefault() && page(`/finance-details/${data.id}`)}
+                            onTouchEnd={e => e.preventDefault() && ReactTooltip.show(e.target)}
                             className="clickable"
                             onFocus={e => ReactTooltip.show(e.target)}
                             onBlur={e => ReactTooltip.hide(e.target)}

--- a/src/shared/js/components/BubbleChartNode.js
+++ b/src/shared/js/components/BubbleChartNode.js
@@ -19,7 +19,7 @@ export default class BubbleChartNode extends React.Component {
         const RorD = node.rdfi[0];
         const WIDTH = 400;
         const HEIGHT = 400;
-        const radius = scaleLinear().domain([0, maxNodeValue]).range([0, WIDTH / 2]);
+        const radius = scaleLinear().domain([0, maxNodeValue]).range([0, WIDTH / 2.5]);
 
         const nodes = hierarchy({name: label, children})
             .sort((a, b) => b.total - a.total);
@@ -27,10 +27,9 @@ export default class BubbleChartNode extends React.Component {
         const bubbles = pack()
             .size([WIDTH, HEIGHT])
             .padding(10)
-            .radius(d => radius(d.data.total))
+            .radius(d => Math.max(radius(d.data.total), 3))
 
         const listMapNodes = bubbles(nodes).children;
-        console.log(label, listMapNodes)
 
         return (<figure className={`bubble-chart rdfi-${RorD}`}>
             <figurelegend>
@@ -39,10 +38,11 @@ export default class BubbleChartNode extends React.Component {
             </figurelegend>
 
             <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`}>
-                {[...listMapNodes.values()].map(({r, x, y, data}) => (
+                {listMapNodes.map(({r, x, y, data}) => (
                     <g key={data.id} transform={`translate(${x}, ${y})`}>
                         <a
-                            href={`#!/finance-details/${data.id}`}
+                            // href={`#!/finance-details/${data.id}`}
+                            onClick={e => e.preventDefault() && page(`/finance-details/${data.id}`)}
                             className="clickable"
                             onFocus={e => ReactTooltip.show(e.target)}
                             onBlur={e => ReactTooltip.hide(e.target)}
@@ -67,7 +67,8 @@ export default class BubbleChartNode extends React.Component {
                 effect='solid'
                 getContent={(nodeId) => {
                     if (!nodeId) return null;
-                    const {data} = listMapNodes.find(d => d.id === nodeId).pop();
+
+                    const {data} = listMapNodes.find(d => d.data.id === nodeId);
                     return (<div className={`rdfi-${data.rdfi[0]} rdfi-${data.rdfi[1]}`}>
                         <p className='react-tooltip-type-aggregation'>
                             {data.rdfi[0] === 'R'? 'Recette': 'Dépense'}


### PR DESCRIPTION
A [cet instant](https://github.com/dtc-innovation/dataviz-finances-montreuil/commit/f17ddb482d8cad1c89ed2d5e1563f98df35f4cde), on peut voir ça pour les recettes : 
![capture d ecran de 2019-03-07 16-04-37](https://user-images.githubusercontent.com/165829/53966210-05337600-40f3-11e9-871e-54fe6e92c0b8.png)

Cette représentation peut donner l'impression au premier coup d'œil (surfaces grises) que la contributions aux recettes des "services généraux" est à peu près les mêmes que celle de "Sport et jeunesse" ou "famille" alors que le premier contribue ~35 fois plus que chacun des deux autres

