### PR TITLE
Les cessions d'immobilisation devraient apparaître en RI et pas en RF

### DIFF
--- a/src/public/js/MontreuilNomenclatureToAggregationDescription.js
+++ b/src/public/js/MontreuilNomenclatureToAggregationDescription.js
@@ -9,6 +9,14 @@ const FORMULA_MAP = {
     'FONCTIONNEMENT': 'F',
 }
 
+function rdfiFromSection (row) {
+    const parts = row['Niveau 1 - Section'].trim().split(' ')
+
+    //returns first and last parts of the Section string
+    //-> [RD, FI]
+    return [ parts[0], parts.pop() ]
+}
+
 function makeFormulaFromMontreuilRows(rows){
     const rowsByRDFI = new Map()
 
@@ -37,7 +45,7 @@ function makeFormulaFromMontreuilRows(rows){
 
         return `${RDFI}*(${rowsFormula})`
     }).join(' + ')
-        
+
 }
 
 function getMontreuilNomenclatureRowKeys(MontreuilNomenclatureRow){
@@ -87,13 +95,20 @@ export default function MontreuilNomenclatureToAggregationDescription(montreuilN
     }
 
     montreuilNomenclature = montreuilNomenclature
-        .filter(r => r["Nature Mvt"] === "REELLE" && 
+        .map(row => {
+            // we patch the Sens and Section from the Niveau 1 label
+            // this is used to override where a content can be located
+            // see https://github.com/dtc-innovation/dataviz-finances-montreuil/issues/101
+            const [Sens, Section] = rdfiFromSection(row)
+            return {...row, Sens, Section}
+        })
+        .filter(r => r["Nature Mvt"] === "REELLE" &&
             docBudgsFonctionNatureCombos.has(makeFonctionNatureCombo(r["Fonction - Code"], r['Nature - Code']))
         )
-        
+
     for(const row of montreuilNomenclature){
         map = map.updateIn(getMontreuilNomenclatureRowKeys(row), val => val ? val.add(row) : new ImmutableSet([row]))
     }
-    
+
     return nomenclatureNodeToAggregationNode(map, 'Budget Montreuil', 'Budget Montreuil');
 }


### PR DESCRIPTION
La M14 dit que c'est en RF, mais avec des opérations d'ordre, c'est en fait en RI
Normalement, la nomenclature Montreuil devrait refléter que c'est en RI