### PR TITLE
Doublons de libellés dans les détails

### DIFF
--- a/src/public/style/finance-element.scss
+++ b/src/public/style/finance-element.scss
@@ -58,6 +58,27 @@
             text-align: right;
         }
 
+        .raw-record.raw-record--nature-detail {
+            color: darken($table-border-color, 20%);
+
+            td:first-of-type {
+                padding-left: .25em;
+
+                &:before {
+                    content: "├─ ";
+                    font-family: monospace;
+                }
+            }
+
+            &.last-item td:first-of-type:before {
+                content: "└─ ";
+            }
+
+            .money-amount {
+                font-weight: normal !important;
+            }
+        }
+
         .raw-record:hover,
         .raw-record:focus {
             background-color: #fff;


### PR DESCRIPTION
Dans `#!/explorer/DEPENSE/INVESTISSEMENT/Dépenses d'équipement/details`, il y a plusieurs fois les mêmes libellés.

![image](https://user-images.githubusercontent.com/138627/62368344-9dac1600-b52c-11e9-8d3f-bab49ed88b70.png)

**Action** : vérifier que c'est cohérent (plusieurs lignes dans le fichier XML 2018 avec le même code Fonction et le même code Nature • `F213 N2313`)